### PR TITLE
SDL cleanup at exit

### DIFF
--- a/src/trs_memory.c
+++ b/src/trs_memory.c
@@ -134,6 +134,7 @@ void trs_exit()
 #ifdef MACOSX
     trs_mac_save_defaults();
 #endif
+    trs_sdl_cleanup();
     exit(0);
 }
 

--- a/src/trs_sdl_interface.c
+++ b/src/trs_sdl_interface.c
@@ -3424,3 +3424,9 @@ void trs_main_load(FILE *file)
   trs_load_int(file,&key_queue_head,1);
   trs_load_int(file,&key_queue_entries,1);
 }
+
+void trs_sdl_cleanup()
+{
+    SDL_FreeSurface(screen);
+    SDL_Quit();
+}

--- a/src/trs_sdl_interface.c
+++ b/src/trs_sdl_interface.c
@@ -3427,6 +3427,17 @@ void trs_main_load(FILE *file)
 
 void trs_sdl_cleanup()
 {
-    SDL_FreeSurface(screen);
-    SDL_Quit();
+    int i, ch;
+
+    for (i = 0; i < 6; i++)
+        for (ch = 0; ch < MAXCHARS; ch++) {
+            free(trs_char[i][ch]->pixels);
+            SDL_FreeSurface(trs_char[i][ch]);
+        }
+    for (i = 0; i < 3; i++)
+        for (ch = 0; ch < 64; ch++)
+            SDL_FreeSurface(trs_box[i][ch]);
+    SDL_FreeSurface(image);
+
+    SDL_Quit(); // Will free screen
 }


### PR DESCRIPTION
Added missing SDL cleanup code at exit to solve frame buffer problems in RetroPie.
